### PR TITLE
Added UNSAFE_ prefix for deprecated lifecycle hooks

### DIFF
--- a/src/Async.js
+++ b/src/Async.js
@@ -72,7 +72,7 @@ export default class Async extends Component {
 		}
 	}
 
-	componentWillReceiveProps(nextProps) {
+	UNSAFE_componentWillReceiveProps(nextProps) {
 		if (nextProps.options !== this.props.options) {
 			this.setState({
 				options: nextProps.options,

--- a/src/Select.js
+++ b/src/Select.js
@@ -109,7 +109,7 @@ class Select extends React.Component {
 		};
 	}
 
-	componentWillMount () {
+	UNSAFE_componentWillMount () {
 		this._instancePrefix = `react-select-${(this.props.instanceId || ++instanceId)}-`;
 		const valueArray = this.getValueArray(this.props.value);
 
@@ -129,7 +129,7 @@ class Select extends React.Component {
 		}
 	}
 
-	componentWillReceiveProps (nextProps) {
+	UNSAFE_componentWillReceiveProps (nextProps) {
 		const valueArray = this.getValueArray(nextProps.value, nextProps);
 
 		if (nextProps.required) {


### PR DESCRIPTION
I just ran this codemod:
https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles

We could move the logic to the safe lifecycle methods, but the component works fine the way it is so it isn't necessary.

After this is merged and released, I will make a PR for https://github.com/Texada/react-virtualized-select